### PR TITLE
Added feature to selector nesting

### DIFF
--- a/lib/parser.php
+++ b/lib/parser.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of Turbine
  * http://github.com/SirPepe/Turbine
- * 
+ *
  * Copyright Peter Kröner
  * Licensed under GNU LGPL 3, see license.txt or http://www.gnu.org/licenses/
  */
@@ -535,7 +535,10 @@ class Parser2 extends Base{
 			foreach($parent as $p){
 				$selector = array();
 				foreach($child as $c){
-					$selector[] = $p.' '.$c;
+					if(strpos($c, '&') !== false)
+						$selector[] = str_replace('&', $p, $c);
+					else
+						$selector[] = $p.' '.$c;
 				}
 				$selectors[] = $selector;
 			}
@@ -918,7 +921,7 @@ class Parser2 extends Base{
 	 * glue_properties
 	 * Combine property sets
 	 * @param mixed $rules Property-value-pairs
-	 * @param string $prefix Prefix 
+	 * @param string $prefix Prefix
 	 * @param bool $compressed Compress CSS? (removes whitespace)
 	 * @return string $output Formatted CSS
 	 */
@@ -1245,3 +1248,4 @@ class Parser2 extends Base{
 
 
 ?>
+


### PR DESCRIPTION
I added a small feature to the nested selector parsing.  Now the parser will first scan the child selector for the & character and, if found, insert the parent at that point.  This allows a few edge cases of inheritance to flow more logically.

For example, the following cssp:

```
#js-warning
    display:none
    .no-js &
        display:block
```

compiles to

```
#js-warning {
    display: none;
}
.no-js #js-warning {
    display: block;
}
```

and code such as

```
a
    color:blue
    &:hover, &:active
        color:red
```

compiles as expected
