### PR TITLE
Selector line parsing no longer fails when checking for poorly formed comments.

### DIFF
--- a/lib/parser.php
+++ b/lib/parser.php
@@ -569,7 +569,7 @@ class Parser2 extends Base{
 		$len = strlen($line);
 		for($i = 0; $i < $len; $i++ ){
 			$this->switch_string_state($line{$i});
-			if($this->state != 'st' && $line{$i} == '/' && $line{$i+1} == '/'){ // Break on comment
+			if($this->state != 'st' && (isset($line{$i}) && $line{$i} == '/') && (isset($line{$i+1}) && $line{$i+1} == '/') ){ // Break on comment
 				break;
 			}
 			$this->token .= $line{$i};


### PR DESCRIPTION
From my rather rushed investigation this is what I _think_ is happening, this fixes the "Uninitialized string offset...on line 578 of parser.php" error which also leads to styles failing to output correctly. 
